### PR TITLE
Updated to better handle multiple submissions

### DIFF
--- a/utils/autogen/Specific/subcrystal_taub.py
+++ b/utils/autogen/Specific/subcrystal_taub.py
@@ -1,20 +1,21 @@
 # RunCrystal for Taub
 
-def execute(px_ssh, infile, outfile):
+def execute(px_ssh, infile, outfile, job_name):
   px_ssh.prompt()
 
-  qscript = """#PBS -l nodes=1:ppn=16
+  qscript = """#PBS -l nodes=1:ppn=12
 #PBS -l walltime=00:30:00
 #PBS -j oe
 #PBS -q secondary
 #PBS -o QSUB.stdout
+#PBS -N %s
 
 cd ${PBS_O_WORKDIR}
 cp %s INPUT
-module load openmpi/1.4-gcc+ifort
-mpirun -np 16 ~/bin/Pcrystal >& %s
+module load openmpi/1.6.4-intel-13.1
+mpirun -np 12 ~/bin/Pcrystal >& %s
 rm fort.*.pe*
-"""%(infile,outfile)
+"""%(job_name, infile,outfile)
   
   px_ssh.sendline("echo '" + qscript + "' > batch_script")
   px_ssh.prompt()

--- a/utils/autogen/Specific/subcrystal_taub.py
+++ b/utils/autogen/Specific/subcrystal_taub.py
@@ -3,7 +3,7 @@
 def execute(px_ssh, infile, outfile, job_name):
   px_ssh.prompt()
 
-  qscript = """#PBS -l nodes=1:ppn=12
+  qscript = """#PBS -l nodes=1:ppn=16
 #PBS -l walltime=00:30:00
 #PBS -j oe
 #PBS -q secondary
@@ -12,8 +12,8 @@ def execute(px_ssh, infile, outfile, job_name):
 
 cd ${PBS_O_WORKDIR}
 cp %s INPUT
-module load openmpi/1.6.4-intel-13.1
-mpirun -np 12 ~/bin/Pcrystal >& %s
+module load openmpi/1.4-gcc+ifort
+mpirun -np 16 ~/bin/Pcrystal >& %s
 rm fort.*.pe*
 """%(job_name, infile,outfile)
   

--- a/utils/autogen/Specific/subqwalk_taub.py
+++ b/utils/autogen/Specific/subqwalk_taub.py
@@ -1,15 +1,17 @@
 # RunVarianceOptimization for Taub
 
-def execute(px_ssh, infile, outfile):
-	qscript = """#PBS -l nodes=1:ppn=16
+def execute(px_ssh, infile, outfile, job_name):
+	qscript = """#PBS -l nodes=1:ppn=12
 #PBS -l walltime=04:00:00
 #PBS -j oe
 #PBS -q secondary
 #PBS -o QSUB.stdout
+#PBS -N %s
 
 cd ${PBS_O_WORKDIR}
-module load openmpi/1.6.5-gcc-4.7.1 intel/14.0
-mpirun -np 16 /projects/wagner/apps/qwalk %s >& %s"""%(infile, outfile)
+module unload openmpi/1.6.4-intel-13.1
+module load openmpi/1.4-intel
+mpirun -np 12 ~/bin/qwalk %s >& %s"""%(job_name, infile, outfile)
 	
 	px_ssh.sendline("echo '" + qscript + "' > batch_script")
 	px_ssh.prompt()

--- a/utils/autogen/Specific/subqwalk_taub.py
+++ b/utils/autogen/Specific/subqwalk_taub.py
@@ -1,7 +1,7 @@
 # RunVarianceOptimization for Taub
 
 def execute(px_ssh, infile, outfile, job_name):
-	qscript = """#PBS -l nodes=1:ppn=12
+	qscript = """#PBS -l nodes=1:ppn=16
 #PBS -l walltime=04:00:00
 #PBS -j oe
 #PBS -q secondary
@@ -9,9 +9,8 @@ def execute(px_ssh, infile, outfile, job_name):
 #PBS -N %s
 
 cd ${PBS_O_WORKDIR}
-module unload openmpi/1.6.4-intel-13.1
-module load openmpi/1.4-intel
-mpirun -np 12 ~/bin/qwalk %s >& %s"""%(job_name, infile, outfile)
+module load openmpi/1.6.5-gcc-4.7.1 intel/14.0
+mpirun -np 16 ~/bin/qwalk %s >& %s"""%(job_name, infile, outfile)
 	
 	px_ssh.sendline("echo '" + qscript + "' > batch_script")
 	px_ssh.prompt()

--- a/utils/autogen/cif2crystal.py
+++ b/utils/autogen/cif2crystal.py
@@ -191,7 +191,7 @@ class Cif2Crystal:
       print("ERROR: only support BFD pseudoptentials for now")
       quit()
 
-    geomlines,primstruct=cif2geom(StringIO(job_record['cif']))
+    geomlines,primstruct=cif2geom(StringIO(unicode(job_record['cif'],"utf-8")))
     basislines=basis_section(primstruct,job_record['dft']['basis'],
                               job_record['dft']['initial_charges'])
     supercell=["SUPERCEL"]

--- a/utils/autogen/run_si.py
+++ b/utils/autogen/run_si.py
@@ -13,8 +13,8 @@ import submission_tools
 
 #An example to submit to the Taub campus cluster.
 #Change these 
-directory="/home/lkwagner/project/tmp/" #the trailing slash is important!
-username="lkwagner"
+directory="/projects/erg/jaschil2/QMCDB/" #the trailing slash is important!
+username="jaschil2"
 
 
 job_record=job_control.default_job_record("si.cif")

--- a/utils/autogen/run_si.py
+++ b/utils/autogen/run_si.py
@@ -13,8 +13,9 @@ import submission_tools
 
 #An example to submit to the Taub campus cluster.
 #Change these 
-directory="/projects/erg/jaschil2/QMCDB/" #the trailing slash is important!
-username="jaschil2"
+directory="this/is/the/remote/directory/" #the trailing slash is important!
+username="johndoe3"
+host = 'taub.campuscluster.illinois.edu'
 
 
 job_record=job_control.default_job_record("si.cif")
@@ -40,8 +41,8 @@ for alpha in [0.1]:
 
 # PX Tools #
 ssh_taub = pxssh.pxssh()
-ssh_taub.login('taub.campuscluster.illinois.edu', username)
-ftp_taub = pexpect.spawn('sftp '+ username+'@taub.campuscluster.illinois.edu')
+ssh_taub.login(host, username)
+ftp_taub = pexpect.spawn('sftp '+ username + '@' + host)
 
 ssh_taub.setecho(True)
 ftp_taub.setecho(True)

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -12,7 +12,7 @@ class RunCrystal:
     self._submitter = submitter
 
   def run(self, job_record):
-    job_record['control'][self._name_+'_jobid'] = [self._submitter.execute(job_record, ['autogen.d12'], 'autogen.d12', 'autogen.d12.o', )]
+    job_record['control'][self._name_+'_jobid'] = [self._submitter.execute(job_record, ['autogen.d12'], 'autogen.d12', 'autogen.d12.o')]
     return 'running'
 
   def output(self,job_record):

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -12,7 +12,7 @@ class RunCrystal:
     self._submitter = submitter
 
   def run(self, job_record):
-    job_record['control'][self._name_+'_jobid'] = self._submitter.execute(job_record, ['autogen.d12'], 'autogen.d12', 'autogen.d12.o')
+    job_record['control'][self._name_+'_jobid'] = [self._submitter.execute(job_record, ['autogen.d12'], 'autogen.d12', 'autogen.d12.o', )]
     return 'running'
 
   def output(self,job_record):
@@ -25,7 +25,6 @@ class RunCrystal:
       
     return job_record
 
-
   def check_outputfile(self,outfilename):
     if os.path.isfile(outfilename):
       f=open(outfilename,'r')
@@ -34,18 +33,13 @@ class RunCrystal:
           if "TOO MANY CYCLES" in line:
             print("Crystal failed: too many cycles.")
             return 'not_finished'
-          energy = float(line.split()[8])
-          if energy > 0.0:
-            print("Crystal failed: energy divergence.") 
-            return 'failed'
-        
           return 'ok'
     else:
       return 'not_started'
 
   def check_status(self,job_record):
     outfilename="autogen.d12.o"
-    self._submitter.output(job_record, ['autogen.d12.o', 'fort.9', 'fort.98'])
+    self._submitter.output(job_record, ['autogen.d12.o', 'fort.9'])
 
     status=self.check_outputfile(outfilename)
     if status=='failed':
@@ -138,10 +132,10 @@ class RunProperties:
       return status
 
     if self._submitter!=None:
-      status=self._submitter.status(job_record,[outfilename,'fort.9'])
+      status=self._submitter.status(job_record)
       if status=='running':
         return status
-      self._submitter.output(job_record, [outfilename])
+      self._submitter.output(job_record, [outfilename, 'fort.9'])
       status=self.check_outputfile(outfilename)
       if status=='ok':
         self._submitter.cancel(job_record['control'][self._name_+'_jobid'])

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -25,6 +25,7 @@ class RunCrystal:
       
     return job_record
 
+
   def check_outputfile(self,outfilename):
     if os.path.isfile(outfilename):
       f=open(outfilename,'r')
@@ -33,6 +34,11 @@ class RunCrystal:
           if "TOO MANY CYCLES" in line:
             print("Crystal failed: too many cycles.")
             return 'not_finished'
+          energy = float(line.split()[8])
+          if energy > 0.0:
+            print("Crystal failed: energy divergence.") 
+            return 'failed'
+
           return 'ok'
     else:
       return 'not_started'

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -78,11 +78,11 @@ wf2 { include qw.jast2 }
 }
 """)
     f.close()
-    job_record['control'][self._name_+'_jobid'] = self._submitter.execute(
+    job_record['control'][self._name_+'_jobid'] = [self._submitter.execute(
       job_record, 
       ['qw_0.opt','qw_0.sys','qw_0.slater','qw_0.orb','qw.basis','qw.jast2'], 
       'qw_0.opt',
-      'qw_0.opt.stdout')
+      'qw_0.opt.stdout')]
     
     return 'running'
 
@@ -152,11 +152,11 @@ include qw_0.sys
 trialfunc { include qw_0.enopt.wfin }
 """%enopt_options['vmc_nstep'])
     f.close()
-    job_record['control'][self._name_+'_jobid'] = self._submitter.execute(
+    job_record['control'][self._name_+'_jobid'] = [self._submitter.execute(
       job_record, 
       ['qw_0.enopt','qw_0.enopt.wfin','qw_0.sys','qw_0.slater','qw_0.orb','qw.basis'],
       'qw_0.enopt',
-      'qw_0.enopt.stdout')
+      'qw_0.enopt.stdout')]
     
     return 'running'
 
@@ -226,6 +226,9 @@ class QWalkRunDMC:
   def run(self,job_record,restart=False):
     qmc_options=job_record['qmc']
     kpts=self.get_kpts(job_record)
+    if self._name_+'_jobid' not in job_record['control'].keys():
+      job_record['control'][self._name_+'_jobid'] = []
+      job_record['control']['queue_id'] = []
     
     #choose which wave function to use
     if not restart:
@@ -248,12 +251,14 @@ class QWalkRunDMC:
               kname+'.orb','qw.basis']
           if restart:
             infiles.extend([basename+'.dmc.config',basename+'.dmc.log'])
-          job_record['control'][self._name_+'_jobid'] = self._submitter.execute(
+          job_id = self._submitter.execute(
             job_record,
             infiles,
             basename+".dmc",
             basename+".dmc.stdout")
+          job_record['control'][self._name_+'_jobid'].append(job_id)
 
+    job_record['control']['queue_id'] = job_record['control'][self._name_+'_jobid']
     return 'running'
 
 

--- a/utils/autogen/submission_tools.py
+++ b/utils/autogen/submission_tools.py
@@ -21,20 +21,25 @@ class RemoteSubmitter:
     self.px_ssh.sendline('cd ' + self.remotePath + job_id)
     self.px_ssh.prompt()
 
-    self.px_ssh.sendline('ls')
-    self.px_ssh.prompt()
-    for dep in infiles:   
+    for dep in infiles:  
+      # print('Transferring file _to_ remote cluster:   ' + dep)     
       self.px_ftp.sendline('put ' + os.getcwd() + '/' + dep + ' ' + self.remotePath + job_id)
       self.px_ftp.expect('sftp>')
 
-    job_record['control']['queue_id'] = self.module.execute(self.px_ssh, runfile, outfile)
-    return job_record['control']['queue_id']
+    job_record['control']['queue_id'] = [self.module.execute(self.px_ssh, runfile, outfile, str(job_record['control']['id']))]
+    return job_record['control']['queue_id'][0]
 
   def status(self, job_record):
     job_id = str(job_record['control']['id'])
     self.px_ssh.sendline('cd ' + self.remotePath + job_id)
     self.px_ssh.prompt()
-    return self.module.status(self.px_ssh, job_record['control']['queue_id'])
+    statuses = []
+    for q_id in job_record['control']['queue_id']:
+      statuses.append(self.module.status(self.px_ssh, q_id))
+    if 'running' in statuses:
+      return 'running'
+    else:
+      return 'not_running'
 
   def output(self, job_record, outfiles):
     job_id = str(job_record['control']['id'])
@@ -45,18 +50,15 @@ class RemoteSubmitter:
     remote_files = self.px_ssh.before.decode('utf-8')
     
     for cop in outfiles:
-      #self.px_ssh.sendline('cd ' + self.remotePath + job_id)
-      #self.px_ssh.prompt()
-      #self.px_ssh.sendline('ls')
-      #self.px_ssh.prompt()
-      #remote_files = self.px_ssh.before.decode('utf-8')
-      #print(remote_files)
       if cop in remote_files:
+        # print('Transferring file _from_ remote cluster:   ' + cop)
         self.px_ftp.sendline('get ' + self.remotePath + job_id + '/' + cop + ' ' + os.getcwd())
         self.px_ftp.expect('sftp>')
       
   def cancel(self, queue_id):
-    output = self.module.cancel(self.px_ssh, queue_id)
+    output = []
+    for q_id in queue_id:
+      output.append(self.module.cancel(self.px_ssh, q_id))
 
 class LocalSubmitter:
   def __init__(self, module):
@@ -67,11 +69,19 @@ class LocalSubmitter:
     job_record['control']['queue_id'] = self.module.execute(runfile, outfile)
 
   def status(self,job_record):
-    return self.module.status(job_record['control']['queue_id'])
+    statuses = []
+    for q_id in job_record['control']['queue_id']:
+      statuses.append(self.module.status(self.px_ssh, q_id))
+    if 'running' in statuses:
+      return 'running'
+    else:
+      return 'not_running'
 
   def output(self,job_record,outfiles):
     pass
 
   def cancel(self, queue_id):
-    output = self.module.cancel(queue_id)
+    output = []
+    for q_id in queue_id:
+      output.append(self.module.cancel(self.px_ssh, q_id))
 


### PR DESCRIPTION
-Submitter handles multiple queue IDs naturally now. Had to make a minor edit to the "run" function in runqwalk's QWalkRunDMC to account for this.
-Fixed bug with crystal properties submission
-cif2crystal did not convert string -> unicode on one line (which caused issues for me) so I edited it to do so
-Added another input for the submission modules in Specific to give batch job names. The system passes the job record id as a name.
