### PR TITLE
Minor change required necessary for energy optimization restart to work.

### DIFF
--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -181,7 +181,7 @@ trialfunc { include qw_0.enopt.wfin }
 
   def check_status(self,job_record):
     outfilename="qw_0.enopt.o"
-    self._submitter.output(job_record, [outfilename])
+    self._submitter.output(job_record, [outfilename, 'qw_0.enopt.wfout])
       
     if self.check_outputfile(outfilename)=='ok':
       self._submitter.cancel(job_record['control'][self._name_+'_jobid'])


### PR DESCRIPTION
QWalk energy optimization did not copy qw_0.enopt.wfout from remote cluster before. Now it does.
