### PR TITLE
Minor changes to runproperties + runcrystal

### DIFF
--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -118,7 +118,7 @@ class RunProperties:
       os.system("properties < prop.in > prop.in.o")
       return 'ok'
     else:
-      job_record['control'][self._name_+'_jobid'] = self._submitter.execute(job_record,["prop.in"])
+      job_record['control'][self._name_+'_jobid'] = self._submitter.execute(job_record,["prop.in"], 'prop.in', 'prop.in.o')
       return 'running'
 
   def check_outputfile(self,outfilename):

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -45,7 +45,6 @@ class RunCrystal:
 
   def check_status(self,job_record):
     outfilename="autogen.d12.o"
-    self._submitter.output(job_record, ['autogen.d12.o', 'fort.9'])
 
     status=self.check_outputfile(outfilename)
     if status=='failed':
@@ -54,6 +53,7 @@ class RunCrystal:
       self._submitter.cancel(job_record['control'][self._name_+'_jobid'])
       return status
 
+    self._submitter.output(job_record, ['autogen.d12.o', 'fort.9'])
     status=self._submitter.status(job_record)
     if status=='running':
       return status


### PR DESCRIPTION
Changed runproperties to correctly mesh with the newest submission tools input for remote calculations. Moved where runcrystal copies files to prevent unnecessary transferring of files.
