### PR TITLE
Variance optimize retry condition fix. 

### DIFF
--- a/utils/autogen/job_control.py
+++ b/utils/autogen/job_control.py
@@ -41,6 +41,7 @@ def default_job_record(filename):
   # e.g. job_record['dft']['restart_from'] = ../successful_run/fort.9
   job_record['dft']['restart_from']=None
   job_record['dft']['smear']=None
+  job_record['dft']['retry_mode']='conservative' # See TODO:See what?
 
   #QMC-specific options
   job_record['qmc']['dmc']={}

--- a/utils/autogen/job_control.py
+++ b/utils/autogen/job_control.py
@@ -41,7 +41,6 @@ def default_job_record(filename):
   # e.g. job_record['dft']['restart_from'] = ../successful_run/fort.9
   job_record['dft']['restart_from']=None
   job_record['dft']['smear']=None
-  job_record['dft']['retry_mode']='conservative' # See TODO:See what?
 
   #QMC-specific options
   job_record['qmc']['dmc']={}

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import glob
 import re
+import shutil
 ####################################################
 
 def crystal_patch_output(propname,outname,patchname):
@@ -89,14 +90,19 @@ wf2 { include qw.jast2 }
     return 'running'
 
 
-  def check_outputfile(self,outfilename,reltol=0.1,abstol=10.):
+  def check_outputfile(self,outfilename,nruns,reltol=0.1,abstol=10.):
     status = 'unknown'
     if os.path.isfile(outfilename):
       outf = open(outfilename,'r')
       outlines = outf.read().split('\n')
-      disps = [float(l.split()[4]) for l in outlines if "dispersion" in l]
+      finlines = [l for l in outlines if "Optimization finished" in l]
+      if len(finlines) < nruns:
+        return 'failed' # This function unstable if job was killed.
+      displines = [l for l in outlines if "dispersion" in l]
+      init_disps = [float(l.split()[4]) for l in displines if "iteration # 1 " in l]
+      disps = [float(l.split()[4]) for l in displines]
       if len(disps) > 1:
-        dispdiff = abs(disps[-1] - disps[0])/disps[-1]
+        dispdiff = abs(disps[-1] - init_disps[-1])/init_disps[-1]
         if (dispdiff < reltol) and disps[-1] < abstol:
           return 'ok'
         else:
@@ -108,25 +114,18 @@ wf2 { include qw.jast2 }
         return 'failed'
     else:
       return 'not_started'
-  #def check_outputfile(self,outfilename):
-  #  if os.path.isfile(outfilename):
-  #    f=open(outfilename,'r')
-  #    for line in f:
-  #      if 'Wall' in line:
-  #        return 'ok'
-  #    return 'running'
-
 
   def check_status(self,job_record):
     outfilename="qw_0.opt.o"
+    nruns=job_record['qmc']['variance_optimize']['nruns']
       
-    if self.check_outputfile(outfilename)=='ok':
+    if self.check_outputfile(outfilename,nruns)=='ok':
       return 'ok'
     status=self._submitter.status(job_record)
     self._submitter.transfer_output(job_record, ['qw_0.opt.o', 'qw_0.opt.wfout'])  
     if status=='running':
       return status
-    status = self.check_outputfile(outfilename)
+    status = self.check_outputfile(outfilename,nruns)
     if status == 'ok':
       return 'ok'
     if status == 'not_finished':
@@ -137,9 +136,16 @@ wf2 { include qw.jast2 }
   def retry(self,job_record):
     if not os.path.isfile("qw_0.opt.wfout"):
       return self.run(job_record)
+    else: # Save previous output.
+      trynum=0
+      while os.path.isfile("%d.qw_0.opt.o"%trynum):
+        trynum += 1
+      shutil.move("qw_0.opt.o","%d.qw_0.opt.o"%trynum)
 
-    inplines = [
-        "method { optimize }",
+    nit=job_record['qmc']['variance_optimize']['niterations']
+    nruns=job_record['qmc']['variance_optimize']['nruns']
+    inplines = ["method { optimize iterations %i } "%nit for i in range(nruns)]
+    inplines += [
         "include qw_0.sys",
         "trialfunc { include qw_0.opt.wfout }"
       ]


### PR DESCRIPTION
- VMC variance optimizer retries 3 ten-step (by default) optimize routines when retry condition is met.
- Retry condition is measured by relative change from first to last iteration of last of three (by default) optimize routines.
- It checks this by looking for final instance of "iteration # 1 " and comparing to the last iteration reported.
- For this to work properly, the job can't be killed prematurely, so I added a check to ensure all `rnuns` 
  runs completed.
-  Calling retry saves the previous qwalk_{k}.opt.o into `trynum`.qwalk_{k}.opt.o, where `trynum` increments from 0 up until it won't overwrite any files by the save.
- I didn't look back a fixed number of iterations because the job can finish before it reaches `maxiterations` if the optimizations is fast enough. Then, for instance, looking back 5 iterations might compare to the previous optimization run if the final optimization run only took 4 steps before reaching dispersion tolerance.

Do we want to allow for the variance optimizer to be killed? Right now it reports failure.
