### PR TITLE
Small extensions to functionality.

### DIFF
--- a/utils/autogen/Specific/mira.py
+++ b/utils/autogen/Specific/mira.py
@@ -1,0 +1,98 @@
+# RunCrystal for Mira
+import subprocess as sub
+from submission_tools import LocalSubmitter
+import os
+
+class LocalMiraSubmitter(LocalSubmitter):
+  """Abstract submission class. Defines interaction with the queuing system."""
+  def __init__(self,time='72:00:00',nn=1,np='allprocs',mode=32,queue='batch'):
+    """ Initialize a submitter object. 
+
+    This part should contain all parts of calculation that user should care
+    about, and all parts that are common to calculations of a certain type (all
+    crystal SCF calculations, for instance)."""
+    self.time  = time
+    self.nn    = nn
+    self.np    = np
+    self.queue = queue
+    self.mode  = mode
+
+  def _job_status(self,queue_id):
+    status = "unknown"
+    print("Queue id",queue_id)
+    try:
+      qstat = sub.check_output(
+          "qstat %s"%queue_id, shell=True
+        ).split('\n')[-2].split()[4]
+    except sub.CalledProcessError:
+      print("Called process error")
+      return "unknown"
+    if qstat == "running" or qstat == "queued":
+      print("Found running")
+      return "running"
+    if qstat == "C" or qstat == "E":
+      print("Found finished")
+      return "finished"
+    return status
+
+  def _job_cancel(self,queue_id):
+    print "Cancel was called, but not implemented"
+
+class LocalMiraCrystalSubmitter(LocalMiraSubmitter):
+  """Fully defined submission class. Defines interaction with specific
+  program to be run."""
+  def _submit_job(self,inpfn,outfn="stdout",jobname="",loc=""):
+    """ Submit a specific job to the queue. 
+    
+    Should not interact with user, and should receive only information specific
+    to instance of a job run."""
+    print("Crystal should not be run on Mira! Skipping this!")
+    return None
+
+class LocalMiraPropertiesSubmitter(LocalMiraSubmitter):
+  """Fully defined submission class. Defines interaction with specific
+  program to be run."""
+  def _submit_job(self,inpfn,outfn="stdout",jobname="",loc=""):
+    """ Submit a specific job to the queue. 
+    
+    Should not interact with user, and should receive only information specific
+    to instance of a job run."""
+    print("Properties should not be run on Mira! Skipping this!")
+    return None
+
+class LocalMiraQwalkSubmitter(LocalMiraSubmitter):
+  """Fully defined submission class. Defines interaction with specific
+  program to be run."""
+  def _submit_job(self,inpfn,outfn="stdout",jobname="",loc=""):
+    """ Submit a specific job to the queue. 
+    
+    Should not interact with user, and should receive only information specific
+    to instance of a job run."""
+    print("Non-DMC should not be run on Mira! Skipping this!")
+    return None
+
+class LocalMiraDMCSubmitter(LocalMiraSubmitter):
+  """Fully defined submission class. Defines interaction with specific
+  program to be run."""
+  def _submit_job(self,inpfns,outfn="stdout",jobname="",loc=""):
+    """ Submit a specific job to the queue. 
+    
+    Should not interact with user, and should receive only information specific
+    to instance of a job run."""
+    time=self.time
+    nproc=512*self.nn
+    qsub = []
+    qsub.append('qsub')
+    qsub.append('-q prod')
+    qsub.append('-A SuperMatSim')
+    qsub.append('-t {time}'.format(time=time))
+    qsub.append('-n {nproc}'.format(nproc=nproc))
+    qsub.append('--mode c%d'%self.mode)
+    qsub.append('-o {outfn}'.format(outfn=outfn))
+    qsub.append('~/bin/qwalk')
+    qsub += inpfns
+    qin = ' '.join(qsub)
+    print(qin); qid = None
+    qid = sub.check_output(qin,shell=True)
+    print "Submitted as %s"%qid
+    return qid

--- a/utils/autogen/Specific/taub.py
+++ b/utils/autogen/Specific/taub.py
@@ -78,6 +78,18 @@ class LocalTaubSubmitter(LocalSubmitter):
     return [qid]
 
 ###############################################################
+class LocalTaubNullSubmitter(LocalTaubSubmitter):
+  """Fully defined submission class. Defines interaction with specific
+  program to be run."""
+  def _submit_job(self,inpfn,outfn="stdout",jobname="",loc=""):
+    """ Do Nothing. Useful for getting autogen to gather output but submit
+    no new jobs.
+    
+    Should not interact with user, and should receive only information specific
+    to instance of a job run."""
+    return [None]
+
+###############################################################
 class LocalTaubCrystalSubmitter(LocalTaubSubmitter):
   """Fully defined submission class. Defines interaction with specific
   program to be run."""
@@ -139,13 +151,14 @@ class LocalTaubQwalkSubmitter(LocalTaubSubmitter):
     
     for f in inpfns:
       exe = BIN+"qwalk %s"%f
+      fulloutfn = f+outfn # Ugly but more functional.
 
       if jobname == "":
         jobname = outfn
       if loc == "":
         loc = os.getcwd()
 
-      qid+=self._qsub(exe,prep_commands,final_commands,jobname,outfn,loc)
+      qid+=self._qsub(exe,prep_commands,final_commands,jobname,fulloutfn,loc)
     return qid
 
 #####################################################################

--- a/utils/autogen/cif2crystal.py
+++ b/utils/autogen/cif2crystal.py
@@ -384,14 +384,16 @@ class Cif2Crystal:
     status = self.run(job_record,outfn="new.autogen.d12")
     new = open("new.autogen.d12",'r').read().split()
     old = open("autogen.d12",'r').read().split()
-    for doesntmatter in ["GUESSP"]:
-      if doesntmatter in new: new.remove("GUESSP")
-      if doesntmatter in old: old.remove("GUESSP")
+    for doesntmatter in ["GUESSP","SAVEWF"]:
+      if doesntmatter in new: new.remove(doesntmatter)
+      if doesntmatter in old: old.remove(doesntmatter)
     if new != old:
-      # This functionality has saved me on numerous occasions,
-      # so I'd like to debug it if there are problems.
-      print("Error: job record inconsistent with past input")
-      return 'failed'
+      if not job_record['assert_nochanges']:
+        print("Warning: job record inconsistent with past input")
+        return 'ok'
+      else:
+        print("Error: job record inconsistent with past input")
+        return 'failed'
     else:
       return 'ok'
 

--- a/utils/autogen/job_control.py
+++ b/utils/autogen/job_control.py
@@ -24,6 +24,7 @@ def default_job_record(filename):
   job_record['pseudopotential']='BFD'
   job_record['charge']=0
   job_record['total_spin']=0
+  job_record['assert_nochanges'] = True # Assert no changes in CRYSTAL input.
 
   #DFT-specific options
   job_record['dft']['symmetrized'] = False # True to use spacegroup symmetry, False for primitive symmetry

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -145,7 +145,13 @@ class RunCrystal:
     moms[up] = 1
     moms[dn] = -1
     moms[zs] = 0
-    return (moms == np.array(init_spins)).all()
+    if len(init_spins)==0:
+      if (moms == np.zeros(moms.shape)).all():
+        return True
+      else:
+        return False
+    else:
+      return (moms == np.array(init_spins)).all()
 #-------------------------------------------------      
   def add_guessp(self,inpfn):
     inplines = open(inpfn,'r').read().split('\n')

--- a/utils/autogen/runcrystal.py
+++ b/utils/autogen/runcrystal.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import numpy as np
 import subprocess as sub
 import shutil
 ####################################################
@@ -14,7 +15,6 @@ class RunCrystal:
           'autogen.d12', 'autogen.d12.o',self._name_)
     return 'running'
 #-------------------------------------------------      
-
   def output(self,job_record):
     """ Collect results from output."""
     if os.path.isfile('autogen.d12.o'):
@@ -37,6 +37,7 @@ class RunCrystal:
   # each query.
   def check_outputfile(self,outfilename,acceptable_scf=0.0):
     """ Check output file. 
+
     Current return values:
     no_record, not_started, ok, too_many_cycles, finished (fall-back),
     scf_fail, not_enough_decrease, divergence, not_finished
@@ -108,8 +109,14 @@ class RunCrystal:
     self._submitter.transfer_output(job_record, ['autogen.d12.o', 'fort.9'])
     status=self.check_outputfile(outfilename)
     print("status",status)
-    if status in ['not_started','ok']:
-      return status
+    if status == 'not_started':
+      return 'not_started'
+    elif status == 'ok':
+      if 'initial_spin' in job_record['dft'].keys():
+        if not self._consistent_spins(outfilename,job_record['dft']['initial_spin']):
+          print("Error: Spin changed from initial configuration!")
+          return self.conservative_diagnose("changed_spins")
+      return 'ok'
     status=diagnose(status)
     if status in ['ok','not_finished','failed']:
       return status
@@ -119,6 +126,26 @@ class RunCrystal:
       return 'not_started'
 
     return 'failed'
+#-------------------------------------------------      
+  def _consistent_spins(self,outfn,init_spins,small_spin=1.0):
+    f = open(outfn, 'r')
+    lines = f.readlines()
+    for li,line in enumerate(lines):
+      if 'TOTAL ATOMIC SPINS' in line:
+        moms = []
+        shift = 1
+        while "TTT" not in lines[li+shift]:
+          moms += map(float,lines[li+shift].split())
+          shift += 1
+    moms = np.array(moms)
+    zs = abs(moms) < small_spin
+    up = moms > 0.
+    dn = moms < 0.
+    moms.dtype = int
+    moms[up] = 1
+    moms[dn] = -1
+    moms[zs] = 0
+    return (moms == np.array(init_spins)).all()
 #-------------------------------------------------      
   def add_guessp(self,inpfn):
     inplines = open(inpfn,'r').read().split('\n')

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -169,8 +169,8 @@ class QWalkVarianceOptimize:
       outf = open(outfilename,'r')
       outlines = outf.read().split('\n')
       finlines = [l for l in outlines if "Optimization finished" in l]
-      #if len(finlines) < nruns:
-      #  return 'failed' # This function unstable if job was killed.
+      if len(finlines) < nruns:
+        return 'failed' # This function unstable if job was killed.
       displines = [l for l in outlines if "dispersion" in l]
       init_disps = [float(l.split()[4]) for l in displines if "iteration # 1 " in l]
       disps = [float(l.split()[4]) for l in displines]
@@ -739,6 +739,10 @@ class QWalkRunDMC:
       if r['results']['properties']['total_energy']['error'][0] < thresh:
         statuses.append("ok")
       else:
+        print("Error too large: {0:.2e}>{1:.2e}".format(
+            r['results']['properties']['total_energy']['error'][0],
+            thresh
+          ))
         statuses.append("not_finished")
     #Finally, decide what to do
     if len(set(statuses))==1:

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -1035,7 +1035,7 @@ class QWalkRunPostProcess:
   def postprocessinput(self,k,t,loc,jast,opt,ppr_options):
     basename=self.gen_basename(k,t,loc,jast,opt)
     nwarmup = self.get_warmup("%s.dmc.log"%basename)
-    tracefn = basename+".dmc.trace"
+    tracefn = basename+".trace"
     if ppr_options['swap_endian']:
       newtracefn = tracefn.replace(".trace",".swap.trace")
       if not os.path.exists(newtracefn):
@@ -1068,10 +1068,15 @@ class QWalkRunPostProcess:
       else:
         print("Since min basis wasn't defined, postprocess can't do OBDM.")
     opt_trans={"energy":"enopt","variance":"opt"}
+    jast_inp=extract_jastrow(open("qw_0.%s.%s.wfout"%(jast,opt_trans[opt])))
     outlines += [
         "}",
         "include qw_%i.sys"%k,
-        "trialfunc { include qw_0.%s.%s.wfout"%(jast,opt_trans[opt]),
+        "trialfunc { slater-jastrow ",
+           "wf1 { include qw_%i.slater } "%(k),
+           "wf2 { ",
+          jast_inp,
+          " } ",
         "}"
       ]
     outstr = '\n'.join(outlines)

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -739,7 +739,7 @@ class QWalkRunDMC:
       if r['results']['properties']['total_energy']['error'][0] < thresh:
         statuses.append("ok")
       else:
-        status.append("not_finished")
+        statuses.append("not_finished")
     #Finally, decide what to do
     if len(set(statuses))==1:
       return statuses[0]
@@ -1006,10 +1006,14 @@ class QWalkRunPostProcess:
   def check_outputfile(self,outfilename):
     if os.path.isfile(outfilename):
       f=open(outfilename,'r')
-      for line in f:
-        if 'Wall' in line:
-          return 'ok'
-      return 'running'
+      # Sometimes output files are large, and this takes forever. 
+      # Instead just search the end.
+      if "Wall" in str(sub.check_output(["tail",outfilename])):
+        return 'ok'
+      else:
+        return 'running'
+    else:
+      return 'not_started'
 
   #-----------------------------------------------
   def get_warmup(self,logfilename):

--- a/utils/autogen/runqwalk.py
+++ b/utils/autogen/runqwalk.py
@@ -966,7 +966,7 @@ class QWalkRunPostProcess:
             for opt in options['optimizer']:
               kname="qw_%i"%k
               basename=self.gen_basename(k,t,loc,jast,opt)
-              if not os.path.exists(basename+".dmc.trace"):
+              if not os.path.exists(basename+".trace"):
                 print("You need a trace file to run postprocess.")
                 return "failed"
               f=open(basename+".post",'w')

--- a/utils/read_numberfluct.py
+++ b/utils/read_numberfluct.py
@@ -34,7 +34,7 @@ def read_number_dens(inpf):
       return None,None
   return data,data_err
 
-def read_number_dens_json(inpf):
+def read_number_dens_likejson(inpf):
   """ Same as read number fluctuation data into format the same as if you used
   the JSON flag instead."""
   data=np.zeros((0,0,0,0,0,0))
@@ -49,29 +49,29 @@ def read_number_dens_json(inpf):
       maxn=int(spl[3])
       nregion=int(spl[5])
 
-      data=np.zeros((maxn,maxn))
-      data_err=np.zeros((maxn,maxn))
-      region=np.zeros((maxn,maxn))
-      spin=np.zeros((maxn,maxn))
-      
+      alldata = []
       for s1 in range(0,nspin):
         for s2 in range(0,nspin):
           for r1 in range(0,nregion):
             for r2 in range(0,nregion):
+              data = {
+                  'region':[r1,r2],
+                  'value':np.zeros((maxn,maxn)),
+                  'error':np.zeros((maxn,maxn)),
+                  'spin':[s1,s2]
+                }
               line=inpf.readline()
-              #print line
               for n1 in range(0,maxn):
                 spl=inpf.readline().split()
                 for n2 in range(0,maxn):
-                  spin[n1,n2] = [s1,s2]
-                  region[n1,n2] = [r1,r2]
-                  data[n1,n2]=float(spl[n2])
+                  data['value'][n1,n2]=float(spl[n2])
                 for n2 in range(maxn,2*maxn):
-                  data_err[s1,s2,r1,r2,n1,n2-maxn]=float(spl[n2])
+                  data['value'][n1,n2-maxn]=float(spl[n2])
+              alldata.append(data)
       break
     elif line == '':
-      return None,None
-  return data,data_err
+      return []
+  return alldata
 
 def moments(data,data_err):
   nspin=data.shape[0]

--- a/utils/read_numberfluct.py
+++ b/utils/read_numberfluct.py
@@ -36,7 +36,9 @@ def read_number_dens(inpf):
 
 def read_number_dens_likejson(inpf):
   """ Same as read number fluctuation data into format the same as if you used
-  the JSON flag instead."""
+  the JSON flag instead.
+  
+  This is not complete yet (some keys are missing), but is functional."""
   data=np.zeros((0,0,0,0,0,0))
   data_err=np.zeros((0,0,0,0,0,0))
   while True:

--- a/utils/read_numberfluct.py
+++ b/utils/read_numberfluct.py
@@ -34,6 +34,45 @@ def read_number_dens(inpf):
       return None,None
   return data,data_err
 
+def read_number_dens_json(inpf):
+  """ Same as read number fluctuation data into format the same as if you used
+  the JSON flag instead."""
+  data=np.zeros((0,0,0,0,0,0))
+  data_err=np.zeros((0,0,0,0,0,0))
+  while True:
+    line=inpf.readline()
+    #print line
+    if line.find("Region fluctuation")!=-1:
+      line=inpf.readline()
+      spl=line.split()
+      nspin=int(spl[1])
+      maxn=int(spl[3])
+      nregion=int(spl[5])
+
+      data=np.zeros((maxn,maxn))
+      data_err=np.zeros((maxn,maxn))
+      region=np.zeros((maxn,maxn))
+      spin=np.zeros((maxn,maxn))
+      
+      for s1 in range(0,nspin):
+        for s2 in range(0,nspin):
+          for r1 in range(0,nregion):
+            for r2 in range(0,nregion):
+              line=inpf.readline()
+              #print line
+              for n1 in range(0,maxn):
+                spl=inpf.readline().split()
+                for n2 in range(0,maxn):
+                  spin[n1,n2] = [s1,s2]
+                  region[n1,n2] = [r1,r2]
+                  data[n1,n2]=float(spl[n2])
+                for n2 in range(maxn,2*maxn):
+                  data_err[s1,s2,r1,r2,n1,n2-maxn]=float(spl[n2])
+      break
+    elif line == '':
+      return None,None
+  return data,data_err
+
 def moments(data,data_err):
   nspin=data.shape[0]
   nregion=data.shape[2]


### PR DESCRIPTION
- Added my Mira submitter scripts.
- Added a `NullSubmitter` so that a script can check results without submitting jobs (useful for Mira or regenerating record.json files).
- Option to allow DFT input to change (instead of error, give a warning).
- Added an assertion that spins are generally pointing the same way as initial_spins is set. This can be overridden by defing new "diagnose" function (e.g. `"optimistic_spins"` or something).
- DMC prints the error if it needs to continue (this is useful to check that DMC is actually making progress and not erroring out every run).
- Added new `read_numberfluct` function that reads in data like it would be if you used the `JSON` option in postprocess. That way old non-autogen data can be merged into an autogen database. The function isn't complete (not all the `JSON` option results are available, but can easily be added as needed) but it's functional for my purposes at least.
