### PR TITLE
Fix deriv. DM default cutoff and fix cutoff json output.

### DIFF
--- a/src/properties/Average_derivative_dm.cpp
+++ b/src/properties/Average_derivative_dm.cpp
@@ -256,7 +256,10 @@ void Average_derivative_dm::jsonOutput(Average_return & avg,Average_return & err
     
     os << "\"drop\":" << avg.vals(counta++)<<endl;
     counte++;
-    os << "}," << endl; //End cutoff block
+    if(i<cutoff_list.GetDim(0)-1)
+      os << "}," << endl; //End cutoff block
+    else
+      os << "}" << endl; //Last cutoff block
   }
 
   os << "}" << endl;

--- a/src/properties/Average_derivative_dm.cpp
+++ b/src/properties/Average_derivative_dm.cpp
@@ -109,7 +109,7 @@ void Average_derivative_dm::read(System * sys, Wavefunction_data * wfdata, vecto
   vector<string> cutsec;
   if(!readsection(words,pos=0,cutsec,"CUTOFF")){
     cutoff_list.Resize(1);
-    cutoff_list(0)=1.0;
+    cutoff_list(0)=1e-6;
   }else{
     cutoff_list.Resize(cutsec.size());
     for(int i=0;i<cutoff_list.GetDim(0);i++) cutoff_list(i)=atof(cutsec[i].c_str());

--- a/src/properties/Average_derivative_dm.cpp
+++ b/src/properties/Average_derivative_dm.cpp
@@ -109,7 +109,7 @@ void Average_derivative_dm::read(System * sys, Wavefunction_data * wfdata, vecto
   vector<string> cutsec;
   if(!readsection(words,pos=0,cutsec,"CUTOFF")){
     cutoff_list.Resize(1);
-    cutoff_list(0)=1e-6;
+    cutoff_list(0)=1e-4;
   }else{
     cutoff_list.Resize(cutsec.size());
     for(int i=0;i<cutoff_list.GetDim(0);i++) cutoff_list(i)=atof(cutsec[i].c_str());


### PR DESCRIPTION
Before, the default cutoff for `Average_derivative_dm` was 1.0, which is removing many walkers and giving me nearly zero for all the derivatives on H2. 

I set it to 1e-4 based on @sapatha2 discussion. 1e-3 is probably also fine.

Also, there was a little syntax error for json output with cutoffs.