### PR TITLE
Patch for JSON output for runs with multiple labels.

### DIFF
--- a/src/properties/gosling.cpp
+++ b/src/properties/gosling.cpp
@@ -325,12 +325,18 @@ int main(int argc, char ** argv) {
         
         if(nfiles < 2) { 
           if(options.json){
+            if(lab==0) 
+              cout<<"["<<endl;
             cout<< "{" << endl;
             cout<<  "\"label\":\"" << labels[lab] << "\"," << endl;
             cout<<  "\"total blocks\":" << allblocks(lab).GetDim(0) <<"," << endl;
             cout<<  "\"reblocking\":" <<  options.reblock <<"," << endl;
             avg.JsonOutput(cout, avg_gen(lab));
             cout << "}" << endl;
+            if(lab+1<nlabels)
+              cout<<","<<endl;
+            else
+              cout<<"]"<<endl;
         }
           else{
           cout << "#####################" << endl;


### PR DESCRIPTION
gosling JSON doesn't output correctly when there is multiple labels (e.g. for reptation MC). 

I patched this by making a top-level list, each element corresponds to a label.